### PR TITLE
[dconf] Allow D-Bus activation only through systemd. JB#52572

### DIFF
--- a/rpm/0001-service-Allow-D-Bus-activation-only-through-systemd.patch
+++ b/rpm/0001-service-Allow-D-Bus-activation-only-through-systemd.patch
@@ -1,0 +1,26 @@
+From f5635511c9ffd4d67930e13f69de2748d50fe6b4 Mon Sep 17 00:00:00 2001
+From: Simo Piiroinen <simo.piiroinen@jolla.com>
+Date: Thu, 12 Aug 2021 12:45:11 +0300
+Subject: [PATCH] service: Allow D-Bus activation only through systemd
+
+Starting D-Bus services should happen only via systemd. Using a dummy
+Exec line in D-Bus configuration ensures that systemd can't be bypassed.
+
+Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>
+---
+ service/ca.desrt.dconf.service.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/service/ca.desrt.dconf.service.in b/service/ca.desrt.dconf.service.in
+index be0b911..eb32a6a 100644
+--- a/service/ca.desrt.dconf.service.in
++++ b/service/ca.desrt.dconf.service.in
+@@ -1,4 +1,4 @@
+ [D-BUS Service]
+ Name=ca.desrt.dconf
+-Exec=@libexecdir@/dconf-service
++Exec=/bin/false
+ SystemdService=dconf.service
+-- 
+2.17.1
+

--- a/rpm/dconf.spec
+++ b/rpm/dconf.spec
@@ -7,6 +7,7 @@ URL:        https://wiki.gnome.org/Projects/dconf
 Source0:    %{name}-%{version}.tar.bz2
 Source1:    user
 Source2:    dconf-update
+Patch1:     0001-service-Allow-D-Bus-activation-only-through-systemd.patch
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 Requires:       oneshot
@@ -30,7 +31,7 @@ Requires:   %{name} = %{version}-%{release}
 Development files for %{name}.
 
 %prep
-%autosetup -n %{name}-%{version}/%{name}
+%autosetup -p1 -n %{name}-%{version}/%{name}
 
 %build
 %meson -Dbash_completion=false \


### PR DESCRIPTION
Starting D-Bus services should happen only via systemd. Using a dummy
Exec line in D-Bus configuration ensures that systemd can't be bypassed.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>