### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/dconf.spec
+++ b/rpm/dconf.spec
@@ -14,10 +14,10 @@ Requires:       oneshot
 Requires:       glib2 >= 2.44.0
 BuildRequires:  pkgconfig(glib-2.0) >= 2.44.0
 BuildRequires:  pkgconfig(dbus-1)
+BuildRequires:  pkgconfig(systemd)
 BuildRequires:  intltool
 BuildRequires:  oneshot
 BuildRequires:  meson
-BuildRequires:  systemd
 
 %description
 dconf is a low-level configuration system. Its main purpose is to provide a


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.