### PR TITLE
[dconf] Remove unnecessary intltool dependency. JB#61290

### DIFF
--- a/rpm/dconf.spec
+++ b/rpm/dconf.spec
@@ -15,7 +15,6 @@ Requires:       glib2 >= 2.44.0
 BuildRequires:  pkgconfig(glib-2.0) >= 2.44.0
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(systemd)
-BuildRequires:  intltool
 BuildRequires:  oneshot
 BuildRequires:  meson
 


### PR DESCRIPTION
Seems not needed since 2015 when dconf-editor was split out of the repository.